### PR TITLE
Include stddef.h to fix compile errors

### DIFF
--- a/lzss.c
+++ b/lzss.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include "lzss.h"
 
 uint_fast32_t decompress( const uint8_t * input, uint8_t * output, uint_fast32_t inlength, uint_fast32_t outlength )


### PR DESCRIPTION
Neither ungi nor unsa will compile without including stddef.h in lzss.c in the latest gcc.